### PR TITLE
#29 CICD minimal testing

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: debian-latest
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -2,26 +2,26 @@ name: Makefile CI
 
 on:
   push:
-    branches: [ "dev" ]
+    branches: [ "main", "dev", "29-cicd-minimal-testing" ]
   pull_request:
-    branches: [ "dev" ]
+    branches: [ "main", "dev" ]
 
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: debian-latest
 
     steps:
     - uses: actions/checkout@v3
 
-    - name: configure
-      run: ./configure
+    #- name: configure
+    #  run: ./configure
 
     - name: Install dependencies
       run: make
 
     - name: Run check
-      run: make check
+      run: make test
 
     - name: Run distcheck
       run: make distcheck

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -24,4 +24,4 @@ jobs:
       run: make test
 
     - name: Run distcheck
-      run: make distcheck
+      run: make release

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Install dependencies
       run: make
 
-    - name: Run check
+    - name: Run tests
       run: make test
 
     - name: Run distcheck

--- a/Makefile
+++ b/Makefile
@@ -3,15 +3,23 @@ VENV=.venv
 PYTHON=$(VENV)/bin/python3
 BIN=$(VENV)/bin/
 
-$(VENV): requirements.txt requirements_test.txt setup.py setup.cfg
+all: $(BIN)activate
+
+$(BIN)activate: requirements.txt setup.py setup.cfg
 	python3 -m venv $(VENV)
 	$(BIN)pip install -U pip setuptools wheel
 	$(BIN)pip install -r requirements.txt
+
+$(BIN)pytest: $(BIN)activate requirements_test.txt
 	$(BIN)pip install -r requirements_test.txt
 
+# shortcuts to use as "Make venv" or "Make vent_test"
+venv: $(BIN)activate
+vent_test: $(BIN)pytest
+
 .PHONY: test
-test: $(VENV)
-	$(PYTHON) -m pytest
+test: vent_test
+	$(BIN)pytest
 
 .PHONY: release
 release: clean test
@@ -19,11 +27,11 @@ release: clean test
 
 .PHONY: upload
 upload: release
-    $(PYTHON) "setup.py upload -r http://TODO.com/pypi"
+	$(PYTHON) setup.py upload
 
 # code linters
 .PHONY: lint
-lint: $(VENV)
+lint: vent_test
 	$(BIN)pre-commit run --all-files
 
 .PHONY: lint-changed

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 VENV=.venv
 PYTHON=$(VENV)/bin/python3
 BIN=$(VENV)/bin/
+SECRETS_SAMPLE=test/elena/domain/services/test_home/secrets-sample.yaml
+SECRETS=test/elena/domain/services/test_home/secrets.yaml
 
 all: $(BIN)activate
 
@@ -10,15 +12,19 @@ $(BIN)activate: requirements.txt setup.py setup.cfg
 	$(BIN)pip install -U pip setuptools wheel
 	$(BIN)pip install -r requirements.txt
 
+# a secrets.yaml is needed to run the test
+$(SECRETS):
+	cp $(SECRETS_SAMPLE) $(SECRETS)
+
 $(BIN)pytest: $(BIN)activate requirements_test.txt
 	$(BIN)pip install -r requirements_test.txt
 
 # shortcuts to use as "Make venv" or "Make vent_test"
 venv: $(BIN)activate
-vent_test: $(BIN)pytest
+venv_test: $(BIN)pytest
 
 .PHONY: test
-test: vent_test
+test: venv_test $(SECRETS)
 	$(BIN)pytest
 
 .PHONY: release
@@ -31,7 +37,7 @@ upload: release
 
 # code linters
 .PHONY: lint
-lint: vent_test
+lint: venv_test
 	$(BIN)pre-commit run --all-files
 
 .PHONY: lint-changed


### PR DESCRIPTION
This runs:
- make test
- make release
on every push or PR on /dev and /main

It's using ubuntu-latest that may cause some python version problems... but it's better this way. I'm adding a task to review this.

If *make release* becomes a problem it can be removed for this step in CICD.