### PR TITLE
fetch_ohlcv_limit & fetch_ohlcv_limit_retry_every_milliseconds in config.yaml

### DIFF
--- a/test/elena/domain/services/test_home/config.yaml
+++ b/test/elena/domain/services/test_home/config.yaml
@@ -13,4 +13,6 @@ BotManager:
   path: bots # relative path under home directory
 ExchangeManager:
   class: "test.elena.domain.services.fake_exchange_manager.FakeExchangeManager"
+  fetch_ohlcv_limit: 100
+  fetch_ohlcv_limit_retry_every_milliseconds: 1000
 

--- a/test/elena/domain/services/test_home/config.yaml
+++ b/test/elena/domain/services/test_home/config.yaml
@@ -15,4 +15,3 @@ ExchangeManager:
   class: "test.elena.domain.services.fake_exchange_manager.FakeExchangeManager"
   fetch_ohlcv_limit: 100
   fetch_ohlcv_limit_retry_every_milliseconds: 1000
-


### PR DESCRIPTION
Hi @pjover I'm not sure this PR is right but it's good for testing the CICD

I found that when I want to record new data _fetch_candles_with_retry fails searching for self._config["fetch_ohlcv_limit"] ([here](https://github.com/Pasta-fantasia/elena/blob/eaba50e362454a9c0762f5fad85e09f76f4ee8f2/elena/adapters/exchange_manager/cctx_exchange_manager.py#L196C32-L196C65))

I'm not sure if adding the config to the test config is the right solution.