### PR TITLE
81 elena error unhandled exception unsupported operand types for float and nonetype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.4.1
+- fix: Elena is not using page_size in the read_candles #81
+
 ## 2.4.0
 - feat: NoiseTrader v0 #77
 - small fixes

--- a/elena/adapters/exchange_manager/cctx_exchange_manager.py
+++ b/elena/adapters/exchange_manager/cctx_exchange_manager.py
@@ -177,7 +177,7 @@ class CctxExchangeManager(ExchangeManager):
             pair,
         )
         conn = self._connect(exchange)
-        candles = self._fetch_candles(conn, pair, time_frame)
+        candles = self._fetch_candles(conn, pair, time_frame, page_size=page_size)
         self._logger.info("Read %d %s candles from %s", candles.shape[0], pair, exchange.id.value)
         return candles
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = elena
-version = 2.4.0
+version = 2.4.1
 author = "L Software Foundation"
 author_email = "fransimo@gmail.com, pjover@gmail.com"
 description = Hexagonal multi exchange crypto currency strategy executor


### PR DESCRIPTION
## 2.4.1
- fix: Elena is not using page_size in the read_candles #81